### PR TITLE
fix(tfstack): null pointer exception once drift is detected

### DIFF
--- a/pkg/tfstack/tfstack.go
+++ b/pkg/tfstack/tfstack.go
@@ -183,7 +183,7 @@ func stackExists(name string, stacks []config.Stack) (stack config.Stack, result
 // driftCalculator returns a detailed number of changes that was detected in the plan
 func driftCalculator(state *tfjson.Plan) (*DriftSum, error) {
 
-	var driftSum *DriftSum
+	var driftSum DriftSum
 	for _, resource := range state.ResourceChanges {
 
 		for _, action := range resource.Change.Actions {
@@ -203,7 +203,7 @@ func driftCalculator(state *tfjson.Plan) (*DriftSum, error) {
 		driftSum.Drift = true
 	}
 
-	return driftSum, nil
+	return &driftSum, nil
 }
 
 // cleanUpPlanFile removes the plan file after the plan has been reported


### PR DESCRIPTION
Null pointer exception once drift is detected after. especially after changing the method of calculating the drift based on json output.
```
DEBU[0000] config file not found, running stack init on each directory that contains .tf files 
DEBU[0000] skipping download, terraform binary found...  version=1.0.6
DEBU[0000] skipping download, terraform binary found...  version=1.2.7
DEBU[0000] initializing terraform...                     stack=gcp-core-staging
DEBU[0000] initializing terraform...                     stack=aws-core-production
DEBU[0000] skipping download, terraform binary found...  version=1.2.7
DEBU[0000] initializing terraform...                     stack=gcp-api-environments-staging
DEBU[0000] skipping download, terraform binary found...  version=1.2.7
DEBU[0000] initializing terraform...                     stack=gcp-api-environments-production
DEBU[0001] running terraform plan...                     stack=aws-core-production
DEBU[0001] running terraform plan...                     stack=gcp-api-environments-production
DEBU[0001] running terraform plan...                     stack=gcp-api-environments-staging
ERRO[0001] runtime error: invalid memory address or nil pointer dereference  stack=aws-core-production
DEBU[0001] running terraform plan...                     stack=gcp-core-staging
ERRO[0001] runtime error: invalid memory address or nil pointer dereference  stack=gcp-core-staging
STACK-NAME                      DRIFT   ADD     CHANGE  DESTROY PATH    TF-VERSION 
gcp-api-environments-production false   0       0       0       gcp/api 1.2.7     
gcp-api-environments-staging    false   0       0       0       gcp/api 1.2.7
```