### PR TITLE
Improve cli - optional parallelism and better progress & final outputs

### DIFF
--- a/terradrift-cli/main.go
+++ b/terradrift-cli/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,23 +26,24 @@ var (
 	configPath       = app.Flag("config", "Path for configuration file holding the stack information").String()
 	extraBackendVars = app.Flag("extra-backend-vars", "Extra backend environment variables ex. GOOGLE_CREDENTIALS, AWS_ACCESS_KEY_ID or AWS_CONFIG_FILE ..etc").StringMap()
 	debug            = app.Flag("debug", "Enable debug mode").Default("false").Bool()
-	generateConfig   = app.Flag("generate-config-only", "Generate a config file based on a provided worksapce").Default("false").Bool()
+	generateConfig   = app.Flag("generate-config-only", "Generate a config file based on a provided workspace").Default("false").Bool()
 	output           = app.Flag("output", "Output format supported: json, yaml and table").Default("table").Enum("table", "json", "yaml")
+	maxParallelPlans = app.Flag("max-parallel-plans", "Maximum number of parallel plans to execute").Default("0").Int() // 0 indicates all projects
+	showProgress     = app.Flag("show-progress", "Show the progress output with workers").Default("true").Bool()
 	version          string
 )
 
 type stackOutput struct {
 	Name    string `json:"name" yaml:"name"`
 	Path    string `json:"path" yaml:"path"`
-	Drift   bool   `json:"drift" yaml:"drift"`
-	Add     int    `json:"add" yaml:"add"`
-	Change  int    `json:"change" yaml:"change"`
-	Destroy int    `json:"destroy" yaml:"destroy"`
+	Drift   string `json:"drift" yaml:"drift"` // Modified to string for "N/A"
+	Add     string `json:"add" yaml:"add"`
+	Change  string `json:"change" yaml:"change"`
+	Destroy string `json:"destroy" yaml:"destroy"`
 	TFver   string `json:"tfver" yaml:"tfver"`
 }
 
 func init() {
-
 	app.Version(version)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -49,91 +51,160 @@ func init() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// if worksapce path is not absolute, make it absolute and add a trailing slash
+	// If workdir path is not absolute, make it absolute and add a trailing slash
 	if !path.IsAbs(*workdir) {
 		absPath, err := filepath.Abs(*workdir)
 		if err != nil {
 			log.Fatalf("Error getting absolute path for workdir: %s", err)
 		}
-
 		*workdir = absPath + "/"
-
 	} else if !strings.HasSuffix(*workdir, "/") {
 		*workdir = *workdir + "/"
 	}
 }
 
-func main() {
+// Function to render the table in the console
+func renderStatusTable(workerStatus map[int]string, plannedCount, errorCount, totalStacks int) {
+	fmt.Print("\033[H\033[2J") // Clear the screen
 
+	// Print header
+	fmt.Println("Worker #\tCurrently Planned Project")
+	fmt.Println("---------------------------------------")
+
+	// Sort worker IDs for ordered output
+	keys := make([]int, 0, len(workerStatus))
+	for k := range workerStatus {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+
+	for _, workerID := range keys {
+		fmt.Printf("  %d\t\t%s\n", workerID+1, workerStatus[workerID])
+	}
+
+	// Print progress line
+	fmt.Printf("\nPlanned projects: %d/%d\n", plannedCount, totalStacks)
+	fmt.Printf("Errored projects: %d\n", errorCount)
+}
+
+func main() {
 	var cfg *config.Config
 	var stackOutputs []stackOutput
 	var err error
 
+	// Load configuration based on the provided flags
 	switch {
-	// if config file is provided, load it and assign it to cfg
 	case *configPath != "":
 		log.WithFields(log.Fields{"config": *configPath}).Debug("loading config file")
 		cfg, err = config.ConfigLoader(*workdir, *configPath)
 		if err != nil {
 			log.Fatalf("Error loading config file: %s", err)
 		}
-
-	// if --generate-config-only flag is provided, generate config file to stdout and exit
 	case *generateConfig:
 		cfg, err = config.ConfigGenerator(*workdir)
 		if err != nil {
 			log.Fatalf("Error generating config file: %s", err)
 		}
-
 		outputWriter(cfg, "yaml")
 		os.Exit(0)
-
-	// if config file is not provided, generate it and assign it to cfg
 	case *configPath == "":
-
 		log.Debug("config file not found, running stack init on each directory that contains .tf files")
 		cfg, err = config.ConfigGenerator(*workdir)
 		if err != nil {
 			log.Fatalf("error generating config file: %s", err)
 		}
-
 	}
 
+	// If maxParallelPlans is set to 0, set it to the total number of stacks (i.e., run all projects in parallel)
+	if *maxParallelPlans == 0 {
+		*maxParallelPlans = len(cfg.Stacks)
+	}
+
+	// Set up worker pool with a limit on parallelism
+	totalStacks := len(cfg.Stacks)
+	stackChan := make(chan config.Stack, totalStacks)
 	var wg sync.WaitGroup
-	for _, stack := range cfg.Stacks {
 
+	workerStatus := make(map[int]string)
+	var mu sync.Mutex
+	plannedCount := 0
+	errorCount := 0
+
+	// Start workers based on maxParallelPlans
+	for i := 0; i < *maxParallelPlans; i++ {
 		wg.Add(1)
-		go func(s config.Stack) {
+		go func(workerID int) {
 			defer wg.Done()
-
-			// catch panic and log it as error to continue to the next stack
-			defer func() {
-				if r := recover(); r != nil {
-					log.WithFields(log.Fields{"stack": s.Name}).Error(r)
+			for stack := range stackChan {
+				// Update the worker's status
+				mu.Lock()
+				workerStatus[workerID] = stack.Name
+				if *showProgress {
+					renderStatusTable(workerStatus, plannedCount, errorCount, totalStacks)
 				}
-			}()
+				mu.Unlock()
 
-			response, tfver, err := tfstack.StackInit(*workdir, s, *extraBackendVars)
-			if err != nil {
-				log.WithFields(log.Fields{"stack": s.Name}).Error(err)
-				response = &tfstack.DriftSum{}
+				// Execute stack planning
+				response, tfver, err := tfstack.StackInit(*workdir, stack, *extraBackendVars)
+				var output stackOutput
+
+				// Check for errors
+				if err != nil {
+					mu.Lock()
+					errorCount++
+					mu.Unlock()
+
+					// Mark as errored with "N/A" fields
+					output = stackOutput{
+						Name:    stack.Name,
+						Path:    stack.Path,
+						Drift:   "N/A",
+						Add:     "N/A",
+						Change:  "N/A",
+						Destroy: "N/A",
+						TFver:   "N/A",
+					}
+				} else {
+					// If no error, fill the stackOutput with actual data
+					output = stackOutput{
+						Name:    stack.Name,
+						Path:    stack.Path,
+						Drift:   strconv.FormatBool(response.Drift),
+						Add:     strconv.Itoa(response.Add),
+						Change:  strconv.Itoa(response.Change),
+						Destroy: strconv.Itoa(response.Destroy),
+						TFver:   tfver,
+					}
+				}
+
+				// Collect output
+				mu.Lock()
+				stackOutputs = append(stackOutputs, output)
+				plannedCount++
+				workerStatus[workerID] = "Idle"
+				if *showProgress {
+					renderStatusTable(workerStatus, plannedCount, errorCount, totalStacks)
+				}
+				mu.Unlock()
 			}
-
-			stackOutputs = append(stackOutputs, stackOutput{
-				Name:    s.Name,
-				Path:    s.Path,
-				Drift:   response.Drift,
-				Add:     response.Add,
-				Change:  response.Change,
-				Destroy: response.Destroy,
-				TFver:   tfver,
-			})
-		}(stack)
-
+		}(i)
 	}
+
+	// Send stacks to the channel for processing
+	for _, stack := range cfg.Stacks {
+		stackChan <- stack
+	}
+	close(stackChan) // Close the channel when done sending stacks
+
+	// Wait for all workers to complete
 	wg.Wait()
 
-	// output the results based on the output flag
+	// Sort final output alphabetically
+	sort.Slice(stackOutputs, func(i, j int) bool {
+		return stackOutputs[i].Name < stackOutputs[j].Name
+	})
+
+	// Output the results based on the output flag
 	switch *output {
 	case "json":
 		outputWriter(stackOutputs, "json")
@@ -141,21 +212,19 @@ func main() {
 		outputWriter(stackOutputs, "yaml")
 	case "table":
 		tableWriter(stackOutputs)
-
 	}
 }
 
 func tableWriter(stackOutputs []stackOutput) {
-
 	columns := []string{"STACK-NAME", "DRIFT", "ADD", "CHANGE", "DESTROY", "PATH", "TF-VERSION"}
 	var data [][]string
 
 	for _, stackOutput := range stackOutputs {
 		row := []string{stackOutput.Name,
-			strconv.FormatBool(stackOutput.Drift),
-			strconv.Itoa(stackOutput.Add),
-			strconv.Itoa(stackOutput.Change),
-			strconv.Itoa(stackOutput.Destroy),
+			stackOutput.Drift,
+			stackOutput.Add,
+			stackOutput.Change,
+			stackOutput.Destroy,
 			stackOutput.Path,
 			stackOutput.TFver,
 		}
@@ -173,16 +242,13 @@ func tableWriter(stackOutputs []stackOutput) {
 	table.SetRowSeparator("")
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
-	table.SetTablePadding("\t") // pad with tabs
+	table.SetTablePadding("\t")
 	table.SetNoWhiteSpace(true)
-	table.AppendBulk(data) // Add Bulk Data
+	table.AppendBulk(data)
 	table.Render()
-
 }
 
-// outputWriter takes a data interface and a format string and outputs the data in the specified format
 func outputWriter(data interface{}, format string) {
-
 	switch format {
 	case "json":
 		o, err := json.Marshal(data)
@@ -197,5 +263,4 @@ func outputWriter(data interface{}, format string) {
 		}
 		fmt.Print(string(o))
 	}
-
 }


### PR DESCRIPTION
1. Parallelism with a new flag `--max-parallel-plans` - default is to plan all at the same time as it is now
1. progress output, showing which worker plans which project, updated in place - can be disabled by the new flag `--show-progress`
1. sorted final output alphabetically
1. extra column in the final output that indicates whether a project failed to plan, marked as true, false otherwise
1. prints planning errors before the final output